### PR TITLE
Mobile-first spacing and responsive bottom navigation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -17,8 +17,8 @@ import TheTabBar from './components/TheTabBar.vue';
 .app-container {
   display: flex;
   flex-direction: column;
-  height: 100vh;
-  width: 100vw;
+  min-height: 100dvh;
+  width: 100%;
   overflow: hidden;
   background-color: var(--color-background);
 }
@@ -26,7 +26,7 @@ import TheTabBar from './components/TheTabBar.vue';
 .main-content {
   flex: 1;
   overflow-y: auto;
-  padding-bottom: 80px; /* Space for tab bar */
+  padding-bottom: calc(var(--tab-bar-height) + env(safe-area-inset-bottom));
   scrollbar-width: none; /* Firefox */
   -ms-overflow-style: none; /* IE and Edge */
 }

--- a/src/components/TheTabBar.vue
+++ b/src/components/TheTabBar.vue
@@ -7,13 +7,13 @@ const tabs = [
 </script>
 
 <template>
-    <nav class="fixed bottom-0 left-0 right-0 bg-card border-t border-gray-5 pb-safe">
-        <div class="flex justify-around items-center h-16">
+    <nav class="tabbar fixed bottom-0 left-0 right-0 z-40 bg-card/95 border-t border-gray-5 pb-safe backdrop-blur-sm">
+        <div class="mx-auto flex justify-around items-center h-16 max-w-lg">
             <router-link
                 v-for="tab in tabs"
                 :key="tab.name"
                 :to="{ name: tab.name }"
-                class="flex flex-col items-center justify-center w-full h-full text-text-secondary hover:text-accent transition-colors"
+                class="flex flex-col items-center justify-center w-full h-full text-text-secondary hover:text-accent transition-colors active:scale-95"
                 active-class="text-accent"
             >
                 <svg
@@ -37,6 +37,10 @@ const tabs = [
 </template>
 
 <style scoped>
+.tabbar {
+  height: calc(var(--tab-bar-height) + env(safe-area-inset-bottom));
+}
+
 .pb-safe {
   padding-bottom: env(safe-area-inset-bottom);
 }

--- a/src/style.css
+++ b/src/style.css
@@ -28,6 +28,7 @@
   --color-gray-5: #E5E5EA;
   --color-gray-6: #F2F2F7;
   --color-accent: #007AFF;
+  --tab-bar-height: 76px;
 }
 
 .dark {
@@ -60,5 +61,5 @@ body::-webkit-scrollbar {
 
 #app {
   width: 100%;
-  height: 100%;
+  min-height: 100dvh;
 }

--- a/src/views/FavoritesView.vue
+++ b/src/views/FavoritesView.vue
@@ -70,30 +70,30 @@ function downloadCsv() {
 </script>
 
 <template>
-    <div class="flex flex-col h-full max-w-lg mx-auto w-full p-4">
+    <div class="flex flex-col h-full max-w-lg mx-auto w-full p-3 sm:p-4">
         <h1 class="text-2xl font-bold text-center mb-4 text-text-primary">
             Kedvencek
         </h1>
 
         <!-- Vote Filter -->
-        <div class="flex bg-gray-5 rounded-lg p-1 mb-4">
+        <div class="flex bg-gray-5 rounded-xl p-1 mb-3">
             <button
                 v-if="store.coupleMode"
-                class="flex-1 py-1.5 text-sm font-medium rounded-md transition-all"
+                class="flex-1 py-2 text-sm font-medium rounded-lg transition-all"
                 :class="voteFilter === 'matches' ? 'bg-card shadow text-purple-600' : 'text-text-secondary'"
                 @click="voteFilter = 'matches'"
             >
                 Találatok ({{ store.matchedNames.length }})
             </button>
             <button
-                class="flex-1 py-1.5 text-sm font-medium rounded-md transition-all"
+                class="flex-1 py-2 text-sm font-medium rounded-lg transition-all"
                 :class="voteFilter === 'like' ? 'bg-card shadow text-green-600' : 'text-text-secondary'"
                 @click="voteFilter = 'like'"
             >
                 Tetszik ({{ store.likedNames.length }})
             </button>
             <button
-                class="flex-1 py-1.5 text-sm font-medium rounded-md transition-all"
+                class="flex-1 py-2 text-sm font-medium rounded-lg transition-all"
                 :class="voteFilter === 'dislike' ? 'bg-card shadow text-red-600' : 'text-text-secondary'"
                 @click="voteFilter = 'dislike'"
             >
@@ -102,11 +102,11 @@ function downloadCsv() {
         </div>
 
         <!-- Gender Filter -->
-        <div class="flex justify-center gap-2 mb-6">
+        <div class="flex justify-center gap-2 mb-4 flex-wrap">
             <button
                 v-for="option in ['all', 'boy', 'girl'] as const"
                 :key="option"
-                class="px-4 py-1.5 rounded-full text-sm font-medium transition-colors"
+                class="px-4 py-2 rounded-full text-sm font-medium transition-colors"
                 :class="genderFilter === option ? 'bg-accent text-white' : 'bg-gray-5 text-text-secondary'"
                 @click="genderFilter = option"
             >
@@ -115,7 +115,7 @@ function downloadCsv() {
         </div>
 
         <!-- Search -->
-        <div class="relative mb-4">
+        <div class="relative mb-3">
             <input
                 v-model="searchQuery"
                 type="text"
@@ -135,7 +135,7 @@ function downloadCsv() {
         <!-- Export -->
         <div
             v-if="displayedNames.length > 0"
-            class="flex gap-2 mb-4"
+            class="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-3"
         >
             <button
                 class="flex-1 py-2 text-sm font-medium rounded-xl bg-card border border-transparent dark:border-gray-800 shadow-sm text-text-primary transition-colors hover:bg-gray-5"
@@ -152,7 +152,7 @@ function downloadCsv() {
         </div>
 
         <!-- List -->
-        <div class="flex-1 overflow-y-auto -mx-4 px-4">
+        <div class="flex-1 overflow-y-auto -mx-3 sm:-mx-4 px-3 sm:px-4">
             <div
                 v-if="displayedNames.length === 0"
                 class="flex flex-col items-center justify-center h-64 text-center text-text-secondary"

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -14,7 +14,7 @@ function handleReset() {
 </script>
 
 <template>
-    <div class="flex flex-col h-full max-w-lg mx-auto w-full p-4 overflow-y-auto">
+    <div class="flex flex-col h-full max-w-lg mx-auto w-full p-3 sm:p-4 overflow-y-auto">
         <h1 class="text-2xl font-bold text-center mb-6 text-text-primary">
             Beállítások
         </h1>

--- a/src/views/SwipeView.vue
+++ b/src/views/SwipeView.vue
@@ -45,18 +45,18 @@ const filterText = computed(() => {
 </script>
 
 <template>
-    <div class="flex flex-col h-full max-w-lg mx-auto w-full p-2 sm:p-4">
+    <div class="flex flex-col h-full max-w-lg mx-auto w-full p-3 sm:p-4 gap-2 sm:gap-3">
         <!-- Gender Toggle -->
-        <div class="flex bg-gray-5 rounded-lg p-1 mb-2">
+        <div class="flex bg-gray-5 rounded-xl p-1">
             <button
-                class="flex-1 py-1.5 text-sm font-medium rounded-md transition-all"
+                class="flex-1 py-2 text-sm font-medium rounded-lg transition-all"
                 :class="store.selectedGender === 'boy' ? 'bg-card shadow text-blue-600' : 'text-text-secondary'"
                 @click="store.setGender('boy')"
             >
                 Fiú
             </button>
             <button
-                class="flex-1 py-1.5 text-sm font-medium rounded-md transition-all"
+                class="flex-1 py-2 text-sm font-medium rounded-lg transition-all"
                 :class="store.selectedGender === 'girl' ? 'bg-card shadow text-pink-600' : 'text-text-secondary'"
                 @click="store.setGender('girl')"
             >
@@ -67,12 +67,12 @@ const filterText = computed(() => {
         <!-- Player Switcher (Couple Mode) -->
         <div
             v-if="store.coupleMode"
-            class="flex bg-gray-5 rounded-lg p-1 mb-2"
+            class="flex bg-gray-5 rounded-xl p-1"
         >
             <button
                 v-for="p in ([1, 2] as Player[])"
                 :key="p"
-                class="flex-1 py-1.5 text-sm font-medium rounded-md transition-all"
+                class="flex-1 py-2 text-sm font-medium rounded-lg transition-all"
                 :class="store.activePlayer === p ? 'bg-card shadow text-accent' : 'text-text-secondary'"
                 @click="store.setActivePlayer(p)"
             >
@@ -83,7 +83,7 @@ const filterText = computed(() => {
         <!-- Filter Indicator -->
         <div
             v-if="store.letterFilter.length > 0"
-            class="flex items-center justify-between bg-orange-100 dark:bg-orange-900/30 text-orange-800 dark:text-orange-200 px-3 py-2 rounded-lg mb-2 text-sm animate-fade-in"
+            class="flex items-center justify-between bg-orange-100 dark:bg-orange-900/30 text-orange-800 dark:text-orange-200 px-3 py-2 rounded-xl text-sm animate-fade-in"
         >
             <div class="flex items-center">
                 <span class="mr-2">🔽</span>
@@ -98,7 +98,7 @@ const filterText = computed(() => {
         </div>
 
         <!-- Progress Bar -->
-        <div class="mb-2">
+        <div class="mb-1">
             <div class="h-2 bg-gray-5 rounded-full overflow-hidden">
                 <div
                     class="h-full transition-all duration-500 ease-out"
@@ -112,7 +112,7 @@ const filterText = computed(() => {
         </div>
 
         <!-- Stats Row -->
-        <div class="flex justify-between items-center px-4 mb-4">
+        <div class="flex justify-between items-center px-2 sm:px-4 mb-2">
             <div class="text-center">
                 <div class="text-lg font-bold text-text-primary">
                     {{ store.totalCount - store.votedCount }}
@@ -148,7 +148,7 @@ const filterText = computed(() => {
         </div>
 
         <!-- Card Stack -->
-        <div class="relative flex-1 w-full max-h-[400px] min-h-[280px]">
+        <div class="relative flex-1 w-full max-h-[460px] min-h-[320px] sm:min-h-[360px]">
             <div
                 v-if="!currentCard"
                 class="flex flex-col items-center justify-center h-full text-center p-6 text-text-primary"
@@ -200,10 +200,10 @@ const filterText = computed(() => {
         <!-- Swipe Buttons -->
         <div
             v-if="currentCard"
-            class="flex justify-center items-center gap-6 mt-4"
+            class="grid grid-cols-2 gap-4 mt-2 mb-1"
         >
             <button
-                class="w-14 h-14 rounded-full bg-red-100 dark:bg-red-900/30 text-red-500 flex items-center justify-center shadow-md hover:scale-110 active:scale-95 transition-transform"
+                class="h-14 rounded-2xl bg-red-100 dark:bg-red-900/30 text-red-500 flex items-center justify-center shadow-md active:scale-95 transition-transform"
                 @click="handleSwipe('left')"
             >
                 <svg
@@ -222,7 +222,7 @@ const filterText = computed(() => {
                 </svg>
             </button>
             <button
-                class="w-14 h-14 rounded-full bg-green-100 dark:bg-green-900/30 text-green-500 flex items-center justify-center shadow-md hover:scale-110 active:scale-95 transition-transform"
+                class="h-14 rounded-2xl bg-green-100 dark:bg-green-900/30 text-green-500 flex items-center justify-center shadow-md active:scale-95 transition-transform"
                 @click="handleSwipe('right')"
             >
                 <svg


### PR DESCRIPTION
### Motivation
- Make the app mobile-first and prevent the fixed bottom navigation from covering content by using dynamic viewport sizing and a shared tab bar height token.
- Improve touch targets, spacing and visual hierarchy on small screens so controls are easier to use with thumbs.
- Make the bottom navigation feel native on phones by honoring safe-area insets and adding a subtle backdrop.

### Description
- Added a CSS token `--tab-bar-height` and switched container sizing to `100dvh` and `min-height` so the UI respects mobile viewport changes and safe areas, and updated `#app` and `main` padding to use `calc(var(--tab-bar-height) + env(safe-area-inset-bottom))` (`src/style.css`, `src/App.vue`).
- Reworked the bottom nav into a centered, constrained `tabbar` with safe-area-aware height, `backdrop-blur-sm`, subtle opacity, and tactile press feedback on links (`src/components/TheTabBar.vue`).
- Tuned `SwipeView` for mobile-first rhythm: increased paddings and rounded styles, made segmented controls and couple-switch larger, adjusted card area min/max heights, and replaced swipe CTA layout with a two-column grid with larger full-width action buttons for easier thumb reach (`src/views/SwipeView.vue`).
- Improved `FavoritesView` and `SettingsView` spacing and responsiveness by tightening container padding, allowing filter chips to wrap, and switching export buttons to a stacked/grid layout on small screens (`src/views/FavoritesView.vue`, `src/views/SettingsView.vue`).

### Testing
- Ran `pnpm build`, which completed successfully (build emitted a chunk-size warning but produced a valid build).
- Ran `pnpm lint`, which completed successfully with automatic fixes applied.
- Captured an updated mobile screenshot of the `Swipe` view to validate layout on a 390×844 viewport (artifact available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6e076f22c8327b99ed569d835b7e1)